### PR TITLE
Feat/whisper ai integration

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -6,6 +6,15 @@ ENV PYTHONUNBUFFERED=1 \
     PIP_NO_CACHE_DIR=1 \
     PIP_DISABLE_PIP_VERSION_CHECK=1
 
+# Install Curl for health checks and FFmpeg for media processing
+RUN apt-get update && apt-get install -y ffmpeg curl unzip ca-certificates && rm -rf /var/lib/apt/lists/*
+
+# Install Deno globally (accessible to all users)
+RUN curl -fsSL https://deno.land/install.sh | sh && \
+    mv /root/.deno/bin/deno /usr/local/bin/deno && \
+    chmod +x /usr/local/bin/deno && \
+    deno --version
+
 # Create a non-root user and set permissions
 RUN useradd -m -u 1000 appuser && \
     mkdir -p /app && \
@@ -16,18 +25,17 @@ WORKDIR /app
 
 # Copy dependencies 
 COPY --chown=appuser:appuser requirements.txt .
-
 # Install all dependencies python 
-RUN pip install --no-cache-dir -r requirements.txt
-
-# Install Curl for health checks and FFmpeg for media processing
-RUN apt-get update && apt-get install -y curl ffmpeg && rm -rf /var/lib/apt/lists/*
+RUN pip install --upgrade pip && pip install --no-cache-dir -r requirements.txt && pip install --no-cache-dir -U yt-dlp
 
 # Copy application code 
 COPY --chown=appuser:appuser app ./app
 
 # Change to non-root user
 USER appuser
+
+# Verify that appuser can access deno
+RUN deno --version
 
 # Expose port 
 EXPOSE 8000

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -20,8 +20,8 @@ COPY --chown=appuser:appuser requirements.txt .
 # Install all dependencies python 
 RUN pip install --no-cache-dir -r requirements.txt
 
-# Install Curl for health checks
-RUN apt-get update && apt-get install -y curl && rm -rf /var/lib/apt/lists/*
+# Install Curl for health checks and FFmpeg for media processing
+RUN apt-get update && apt-get install -y curl ffmpeg && rm -rf /var/lib/apt/lists/*
 
 # Copy application code 
 COPY --chown=appuser:appuser app ./app

--- a/backend/app/api/v1/router.py
+++ b/backend/app/api/v1/router.py
@@ -1,3 +1,4 @@
+from typing import List
 from fastapi import APIRouter, status, UploadFile, File
 from app.schemas.transcription import TranscriptionCreate, TranscriptionResponse
 from app.models.transcription import TranscriptionModel
@@ -94,3 +95,14 @@ async def create_transcription_file(file: UploadFile = File(...)):
         "backup_url": new_transcription.backup_url,
         "created_at": new_transcription.created_at
     }
+
+# Endpoint to get all transcriptions
+@router.get("/", response_model=List[TranscriptionResponse], status_code=status.HTTP_200_OK)
+async def get_all_transcriptions():
+    transcriptions_cursor = db_conn.db.transcriptions.find()
+    transcriptions = []
+    async for transcription in transcriptions_cursor:
+        transcription['id'] = str(transcription['_id'])
+        del transcription['_id']
+        transcriptions.append(TranscriptionResponse(**transcription))
+    return transcriptions

--- a/backend/app/api/v1/router.py
+++ b/backend/app/api/v1/router.py
@@ -1,4 +1,4 @@
-from fastapi import APIRouter, HTTPException, status, UploadFile, File
+from fastapi import APIRouter, status, UploadFile, File
 from app.schemas.transcription import TranscriptionCreate, TranscriptionResponse
 from app.models.transcription import TranscriptionModel
 from app.tasks.transcription import process_video_task
@@ -24,6 +24,7 @@ async def create_transcription(payload: TranscriptionCreate):
     new_transcription = TranscriptionModel(
         video_url=str(payload.video_url),
         status="pending",
+        backup_url="pending"
     )
 
     # Save to database
@@ -41,6 +42,7 @@ async def create_transcription(payload: TranscriptionCreate):
         "id": str(result.inserted_id),
         "video_url": new_transcription.video_url,
         "status": new_transcription.status,
+        "backup_url": new_transcription.backup_url,
         "created_at": new_transcription.created_at
     }
 
@@ -49,7 +51,8 @@ async def create_transcription(payload: TranscriptionCreate):
 async def create_transcription_file(file: UploadFile = File(...)):
     new_transcription = TranscriptionModel(
         video_url="pending",
-        status="pending"
+        status="pending",
+        backup_url="pending"
     )
 
     # Save to database
@@ -88,5 +91,6 @@ async def create_transcription_file(file: UploadFile = File(...)):
         "id": str(result.inserted_id),
         "video_url": new_transcription.video_url,
         "status": new_transcription.status,
+        "backup_url": new_transcription.backup_url,
         "created_at": new_transcription.created_at
     }

--- a/backend/app/api/v1/router.py
+++ b/backend/app/api/v1/router.py
@@ -63,7 +63,7 @@ async def create_transcription_file(file: UploadFile = File(...)):
 
     # Create tmp directory if it doesn't exist
     os.makedirs('/app/tmp', exist_ok=True)
-    tmp_filename = f'{str(result.inserted_id)}_file.{file.filename.split(".")[-1]}'
+    tmp_filename = f'{str(result.inserted_id)}_file{os.path.splitext(file.filename)[1]}'
     tmp_filepath = f'/app/tmp/{tmp_filename}'
 
     with open(tmp_filepath, "wb") as f:
@@ -116,7 +116,7 @@ async def delete_transcription(transcription_id: str):
     if not transcription:
         return {"error": "Transcription not found"}
     
-    # Extract object name from backup_url
+    # Delete the associated backup file from MinIO and the transcription from the database
     try:
         client = Minio(
             settings.MINIO_ENDPOINT,
@@ -128,8 +128,8 @@ async def delete_transcription(transcription_id: str):
             settings.MINIO_BUCKET,
             f'audios/{transcription_id}.mp3'
         )
+        await db_conn.db.transcriptions.delete_one({"_id": ObjectId(transcription_id)})
     except S3Error as e:
-        logger.error(f'Error deleting backup from MinIO: {e}')
+        logger.error(f'Error deleting transcription: {e}')
         raise e
-    await db_conn.db.transcriptions.delete_one({"_id": ObjectId(transcription_id)})
     return {"message": "Transcription deleted successfully"}

--- a/backend/app/api/v1/router.py
+++ b/backend/app/api/v1/router.py
@@ -7,6 +7,7 @@ from app.core.database import db_conn
 import logging
 import shutil
 import os
+from bson import ObjectId
 from minio import Minio
 from minio.error import S3Error
 from app.core.config import settings
@@ -106,3 +107,29 @@ async def get_all_transcriptions():
         del transcription['_id']
         transcriptions.append(TranscriptionResponse(**transcription))
     return transcriptions
+
+# Endpoint to delete a transcription by ID
+@router.delete("/{transcription_id}", status_code=status.HTTP_200_OK)
+async def delete_transcription(transcription_id: str):
+    # Get the transcription to find associated backup file
+    transcription =  await db_conn.db.transcriptions.find_one({"_id": ObjectId(transcription_id)})
+    if not transcription:
+        return {"error": "Transcription not found"}
+    
+    # Extract object name from backup_url
+    try:
+        client = Minio(
+            settings.MINIO_ENDPOINT,
+            access_key=settings.MINIO_ROOT_USER,
+            secret_key=settings.MINIO_ROOT_PASSWORD,
+            secure=False
+        )
+        client.remove_object(
+            settings.MINIO_BUCKET,
+            f'audios/{transcription_id}.mp3'
+        )
+    except S3Error as e:
+        logger.error(f'Error deleting backup from MinIO: {e}')
+        raise e
+    await db_conn.db.transcriptions.delete_one({"_id": ObjectId(transcription_id)})
+    return {"message": "Transcription deleted successfully"}

--- a/backend/app/api/v1/router.py
+++ b/backend/app/api/v1/router.py
@@ -1,10 +1,14 @@
-from fastapi import APIRouter, HTTPException, status
+from fastapi import APIRouter, HTTPException, status, UploadFile, File
 from app.schemas.transcription import TranscriptionCreate, TranscriptionResponse
 from app.models.transcription import TranscriptionModel
 from app.tasks.transcription import process_video_task
 from app.core.database import db_conn
-from datetime import datetime
 import logging
+import shutil
+import os
+from minio import Minio
+from minio.error import S3Error
+from app.core.config import settings
 
 router = APIRouter()
 
@@ -13,6 +17,7 @@ logging.basicConfig(level=logging.INFO,
 
 logger = logging.getLogger(__name__)
 
+# Endpoint for when they are links to videos or audio
 @router.post("/", response_model=TranscriptionResponse, status_code=status.HTTP_201_CREATED)
 async def create_transcription(payload: TranscriptionCreate):
     # Create a new transcription entry in the database
@@ -32,6 +37,53 @@ async def create_transcription(payload: TranscriptionCreate):
         logger.error(f"Failed to trigger background task: {e}")
         raise e
 
+    return {
+        "id": str(result.inserted_id),
+        "video_url": new_transcription.video_url,
+        "status": new_transcription.status,
+        "created_at": new_transcription.created_at
+    }
+
+# Endpoint for when they upload video or audio files
+@router.post("/file", response_model=TranscriptionResponse, status_code=status.HTTP_201_CREATED)
+async def create_transcription_file(file: UploadFile = File(...)):
+    new_transcription = TranscriptionModel(
+        video_url="pending",
+        status="pending"
+    )
+
+    # Save to database
+    transcription_dict = new_transcription.model_dump(by_alias=True)
+    result = await db_conn.db.transcriptions.insert_one(transcription_dict)
+
+    # Create tmp directory if it doesn't exist
+    os.makedirs('/app/tmp', exist_ok=True)
+    tmp_filename = f'{str(result.inserted_id)}_file.{file.filename.split(".")[-1]}'
+    tmp_filepath = f'/app/tmp/{tmp_filename}'
+
+    with open(tmp_filepath, "wb") as f:
+        shutil.copyfileobj(file.file, f)
+
+    # Upload file to MinIO tmp location
+    try:
+        client = Minio(
+            settings.MINIO_ENDPOINT,
+            access_key=settings.MINIO_ROOT_USER,
+            secret_key=settings.MINIO_ROOT_PASSWORD,
+            secure=False
+        )
+        client.fput_object(settings.MINIO_BUCKET, f"temp_uploads/{tmp_filename}", tmp_filepath, content_type=file.content_type)
+        videoUrl_minio = f"http://{settings.MINIO_ENDPOINT}/{settings.MINIO_BUCKET}/temp_uploads/{tmp_filename}"
+    except S3Error as e:
+        logger.error(f'Error uploading file to MinIO: {e}')
+        raise e
+    
+    process_video_task.delay(str(result.inserted_id), videoUrl_minio)
+
+    for path in [tmp_filepath]:
+        if os.path.exists(path):
+            os.remove(path)
+    
     return {
         "id": str(result.inserted_id),
         "video_url": new_transcription.video_url,

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -3,8 +3,10 @@ from pydantic_settings import BaseSettings
 
 class Settings(BaseSettings):
     # MinIO settings
+    MINIO_ENDPOINT: str
     MINIO_ROOT_USER: str 
     MINIO_ROOT_PASSWORD: str
+    MINIO_BUCKET: str
     # MongoDB settings
     MONGODB_URI: str 
     MONGO_INITDB_DATABASE: str

--- a/backend/app/models/transcription.py
+++ b/backend/app/models/transcription.py
@@ -23,6 +23,7 @@ class TranscriptionModel(BaseModel):
     video_url: str
     status: str = "pending" # e.g., 'pending', 'processing', 'completed', 'failed'
     text: Optional[str] = None
+    backup_url: str
     created_at: datetime = Field(default_factory=datetime.utcnow)
 
     class Config:
@@ -34,6 +35,7 @@ class TranscriptionModel(BaseModel):
                 "video_url": "http://example.com/video.mp4",
                 "status": "pending",
                 "text": None,
+                "backup_url": "http://example.com/backup.mp3",
                 "created_at": "2024-01-01T00:00:00Z"
             }
         }

--- a/backend/app/schemas/transcription.py
+++ b/backend/app/schemas/transcription.py
@@ -4,7 +4,6 @@ from typing import Optional
 
 class TranscriptionCreate(BaseModel):
     video_url: HttpUrl
-    backup_url: HttpUrl
 
 class TranscriptionResponse(BaseModel):
     id: str

--- a/backend/app/schemas/transcription.py
+++ b/backend/app/schemas/transcription.py
@@ -4,10 +4,12 @@ from typing import Optional
 
 class TranscriptionCreate(BaseModel):
     video_url: HttpUrl
+    backup_url: HttpUrl
 
 class TranscriptionResponse(BaseModel):
     id: str
     video_url: str
     status: str
     text: Optional[str] = None
+    backup_url: str
     created_at: datetime

--- a/backend/app/tasks/transcription.py
+++ b/backend/app/tasks/transcription.py
@@ -15,6 +15,9 @@ from app.core.config import settings
 
 logger = logging.getLogger(__name__)
 
+# Load the model
+model = whisper.load_model('base')
+
 async def get_db():
     try:
         mongodb_uri = f"mongodb://{settings.MONGO_INITDB_ROOT_USERNAME}:{settings.MONGO_INITDB_ROOT_PASSWORD}@{settings.MONGODB_URI}"
@@ -25,8 +28,17 @@ async def get_db():
         raise e
 
 # Functions 
-def _download_video_sync(url: str, filepath: str, transcription_id: str):
-    # Verify if URL is from YouTube
+def _download_video_sync(url: str, transcription_id: str):
+    response = requests.get(url, stream=True, headers={
+            'User-Agent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36'
+        })
+    response.raise_for_status()
+    content_type = response.headers.get('Content-Type', '').lower()
+
+    # Create tmp directory if it doesn't exist
+    os.makedirs('/app/tmp', exist_ok=True)
+
+    # Case 1: Yotube Video
     if "youtube.com" in url or "youtu.be" in url:
         ydl_opts = {
             'format': 'bestaudio[ext=m4a]/bestaudio/best',
@@ -54,23 +66,35 @@ def _download_video_sync(url: str, filepath: str, transcription_id: str):
 
         with yt_dlp.YoutubeDL(ydl_opts) as ydl:
             ydl.extract_info(url, download=True)
-        return True
-    else:
-        response = requests.get(url, stream=True, headers={
-            'User-Agent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36'
-        })
-        response.raise_for_status()
-        with open(filepath, 'wb') as f:
+        return
+    
+    # Case 2: Link direct to audio or video
+    if "audio" in content_type or "video" in content_type:
+        path_temp = f'/app/tmp/{transcription_id}_tmp'
+
+        with open(path_temp, 'wb') as f:
             for chunk in response.iter_content(chunk_size=8192):
                 f.write(chunk)
-        return False
 
-def _convert_to_audio_sync(videoFilepath: str, audioFilepath: str):
-    try:
-        ffmpeg.input(videoFilepath).output(audioFilepath, acodec='libmp3lame', audio_bitrate='192k').overwrite_output().run(capture_stdout=True, capture_stderr=True)
-    except ffmpeg.Error as e:
-        logger.error(f'FFmpeg error: {e.stderr.decode()}')
-        raise e
+        if "audio" in content_type:
+            os.rename(path_temp, f'/app/tmp/{transcription_id}.mp3')
+            return
+        elif "video" in content_type:
+            try:
+                (
+                    ffmpeg.input(path_temp).output(f'/app/tmp/{transcription_id}.mp3', acodec='libmp3lame', audio_bitrate='192k').overwrite_output().run(quiet=True)
+                )
+                if os.path.exists(path_temp):
+                    os.remove(path_temp)
+            except Exception as e:
+                logger.error(f'Error converting video to audio: {e}')
+                raise e
+            return
+        else:
+            if os.path.exists(path_temp):
+                os.remove(path_temp)
+            raise Exception(f'Unsupported content type: {content_type}')
+    # Case 3: Audio file attachment
     
 def _upload_to_minio_sync(filepath: str, object_name: str):
     try:
@@ -91,23 +115,14 @@ async def download_video(url: str, filepath: str, name_id: str):
 
     try:
         loop = asyncio.get_event_loop()
-        is_already_audio = await loop.run_in_executor(None, _download_video_sync, url, filepath, name_id)
+        await loop.run_in_executor(None, _download_video_sync, url, name_id)
 
-        # Convert to audio
-        try:
-            if not is_already_audio:
-                await loop.run_in_executor(None, _convert_to_audio_sync, filepath, audio_path)
-                # logger.info(f'Video converted to audio at {audio_path}')
-
-            await loop.run_in_executor(None, _upload_to_minio_sync, audio_path, f"audios/{name_id}.mp3")
-            # logger.info(f'Audio uploaded to MinIO as audios/{name_id}.mp3')
-        except Exception as e:
-            logger.error(f'Error during video to audio conversion or upload: {e}')
-            raise e
-        finally:
-            # Clean up local video file
-            if os.path.exists(filepath):
-                os.remove(filepath)
+        await loop.run_in_executor(None, _upload_to_minio_sync, audio_path, f"audios/{name_id}.mp3")
+        logger.info(f'Audio uploaded to MinIO as audios/{name_id}.mp3')
+        
+        # Clean up local video file
+        if os.path.exists(filepath):
+            os.remove(filepath)
     except Exception as e:
         logger.error(f'Error to processing video from {url}: {e}')
         raise e
@@ -123,7 +138,7 @@ async def upload_to_minio(filepath: str, object_name: str):
 
 @celery_app.task(name="process_video_task")
 def process_video_task(transcription_id: str, video_url: str):
-    # logger.info(f'Starting processing for ID: {transcription_id}')
+    logger.info(f'Starting processing for ID: {transcription_id}')
     video_path = f"/app/tmp/{transcription_id}.mp4"
     audio_path = f"/app/tmp/{transcription_id}.mp3"
 
@@ -150,19 +165,16 @@ def process_video_task(transcription_id: str, video_url: str):
 
         # Download video and convert to audio
         loop.run_until_complete(download_video(video_url, video_path, transcription_id))
-
-        # Load the model
-        model = whisper.load_model('base')
         
         # Transcribe audio
-        # logger.info(f'Starting transcription for ID: {transcription_id}')
+        logger.info(f'Starting transcription for ID: {transcription_id}')
         result = model.transcribe(audio_path, fp16=False)
         transcribed_text = result.get('text', '')
 
         # Free memory used by the model
-        del model
-        import gc
-        gc.collect()
+        # del model
+        # import gc
+        # gc.collect()
 
         # Update status to 'completed'
         loop.run_until_complete(update_status('completed', {"text": transcribed_text}))

--- a/backend/app/tasks/transcription.py
+++ b/backend/app/tasks/transcription.py
@@ -1,6 +1,13 @@
 import time
 import logging
 import asyncio
+import ffmpeg
+import requests
+import whisper
+import os
+import yt_dlp
+from minio import Minio
+from minio.error import S3Error
 from bson import ObjectId
 from motor.motor_asyncio import AsyncIOMotorClient
 from app.core.celery_app import celery_app
@@ -17,9 +24,108 @@ async def get_db():
         logger.error(f"Error connecting to MongoDB: {e}")
         raise e
 
+# Functions 
+def _download_video_sync(url: str, filepath: str, transcription_id: str):
+    # Verify if URL is from YouTube
+    if "youtube.com" in url or "youtu.be" in url:
+        ydl_opts = {
+            'format': 'bestaudio[ext=m4a]/bestaudio/best',
+            'postprocessors': [{
+                'key': 'FFmpegExtractAudio',
+                'preferredcodec': 'mp3',
+                'preferredquality': '192',
+            }],
+            'outtmpl': f'/app/tmp/{transcription_id}.%(ext)s',
+            'extractor_args': {
+                'youtube': {
+                    'player_client': ['android', 'ios'],
+                }
+            },
+            'http_headers': {
+                'User-Agent': 'Mozilla/5.0 (Linux; Android 13)',
+                'Accept': '*/*',
+                'Accept-Language': 'en-US,en;q=0.9',
+                'Origin': 'https://www.youtube.com',
+                'Referer': 'https://www.youtube.com/',
+            },
+            'nocheckcertificate': True,
+            'quiet': False,
+        }
+
+        with yt_dlp.YoutubeDL(ydl_opts) as ydl:
+            ydl.extract_info(url, download=True)
+        return True
+    else:
+        response = requests.get(url, stream=True, headers={
+            'User-Agent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36'
+        })
+        response.raise_for_status()
+        with open(filepath, 'wb') as f:
+            for chunk in response.iter_content(chunk_size=8192):
+                f.write(chunk)
+        return False
+
+def _convert_to_audio_sync(videoFilepath: str, audioFilepath: str):
+    try:
+        ffmpeg.input(videoFilepath).output(audioFilepath, acodec='libmp3lame', audio_bitrate='192k').overwrite_output().run(capture_stdout=True, capture_stderr=True)
+    except ffmpeg.Error as e:
+        logger.error(f'FFmpeg error: {e.stderr.decode()}')
+        raise e
+    
+def _upload_to_minio_sync(filepath: str, object_name: str):
+    try:
+        client = Minio(
+            "minio:9000",
+            access_key=settings.MINIO_ROOT_USER,
+            secret_key=settings.MINIO_ROOT_PASSWORD,
+            secure=False
+        )
+        bucket_name = "vidwhisper-engine"
+        client.fput_object(bucket_name, object_name, filepath)
+    except S3Error as e:
+        logger.error(f'Error uploading video to MinIO: {e}')
+        raise e
+    
+async def download_video(url: str, filepath: str, name_id: str):
+    audio_path = f"/app/tmp/{name_id}.mp3"
+
+    try:
+        loop = asyncio.get_event_loop()
+        is_already_audio = await loop.run_in_executor(None, _download_video_sync, url, filepath, name_id)
+
+        # Convert to audio
+        try:
+            if not is_already_audio:
+                await loop.run_in_executor(None, _convert_to_audio_sync, filepath, audio_path)
+                # logger.info(f'Video converted to audio at {audio_path}')
+
+            await loop.run_in_executor(None, _upload_to_minio_sync, audio_path, f"audios/{name_id}.mp3")
+            # logger.info(f'Audio uploaded to MinIO as audios/{name_id}.mp3')
+        except Exception as e:
+            logger.error(f'Error during video to audio conversion or upload: {e}')
+            raise e
+        finally:
+            # Clean up local video file
+            if os.path.exists(filepath):
+                os.remove(filepath)
+    except Exception as e:
+        logger.error(f'Error to processing video from {url}: {e}')
+        raise e
+
+    
+async def upload_to_minio(filepath: str, object_name: str):
+    try:
+        loop = asyncio.get_event_loop()
+        await loop.run_in_executor(None, _upload_to_minio_sync, filepath, object_name)
+    except S3Error as e:
+        logger.error(f'Error uploading to MinIO: {e}')
+        raise e
+
 @celery_app.task(name="process_video_task")
 def process_video_task(transcription_id: str, video_url: str):
     # logger.info(f'Starting processing for ID: {transcription_id}')
+    video_path = f"/app/tmp/{transcription_id}.mp4"
+    audio_path = f"/app/tmp/{transcription_id}.mp3"
 
     try:
         loop = asyncio.get_event_loop()
@@ -42,14 +148,33 @@ def process_video_task(transcription_id: str, video_url: str):
         # Change status to 'pending'
         loop.run_until_complete(update_status('processing'))
 
-        # Simulate video processing
-        time.sleep(10)
+        # Download video and convert to audio
+        loop.run_until_complete(download_video(video_url, video_path, transcription_id))
+
+        # Load the model
+        model = whisper.load_model('base')
+        
+        # Transcribe audio
+        # logger.info(f'Starting transcription for ID: {transcription_id}')
+        result = model.transcribe(audio_path, fp16=False)
+        transcribed_text = result.get('text', '')
+
+        # Free memory used by the model
+        del model
+        import gc
+        gc.collect()
 
         # Update status to 'completed'
-        loop.run_until_complete(update_status('completed', {"text": "Successfully transcribed text."}))
+        loop.run_until_complete(update_status('completed', {"text": transcribed_text}))
 
         return { "status": "success", "id": transcription_id }
     except Exception as e:
         logger.error(f'Error processing video for ID: {transcription_id}, error: {e}')
         loop.run_until_complete(update_status('failed'))
         return { "status": "failed", "message": str(e) }
+    finally:
+        # Clean up local audio file
+        for path in [video_path, audio_path]:
+            if os.path.exists(path):
+                os.remove(path)
+                # logger.info(f'Cleaned up temporary files for ID: {transcription_id}')

--- a/backend/app/tasks/transcription.py
+++ b/backend/app/tasks/transcription.py
@@ -1,4 +1,3 @@
-import time
 import logging
 import asyncio
 import ffmpeg
@@ -12,7 +11,6 @@ from bson import ObjectId
 from motor.motor_asyncio import AsyncIOMotorClient
 from app.core.celery_app import celery_app
 from app.core.config import settings
-from typing import Optional
 
 logger = logging.getLogger(__name__)
 
@@ -179,6 +177,13 @@ def process_video_task(transcription_id: str, video_url: str):
                 {"_id": ObjectId(transcription_id)},
                 {"$set": {"video_url": url}}
             )
+    async def set_backup_url(id: str):
+        db = await get_db()
+        backup_url = f'http://{settings.MINIO_ENDPOINT}/{settings.MINIO_BUCKET}/audios/{id}.mp3'
+        await db.transcriptions.update_one(
+            {"_id": ObjectId(id)},
+            {"$set": {"backup_url": backup_url}}
+        )
 
     try:
         # Change status to 'pending'
@@ -199,6 +204,7 @@ def process_video_task(transcription_id: str, video_url: str):
 
         # Update status to 'completed'
         loop.run_until_complete(update_video_url(f'http://{settings.MINIO_ENDPOINT}/{settings.MINIO_BUCKET}/audios/{transcription_id}.mp3'))
+        loop.run_until_complete(set_backup_url(transcription_id))
         loop.run_until_complete(update_status('completed', {"text": transcribed_text}))
 
         return { "status": "success", "id": transcription_id }

--- a/backend/app/tasks/transcription.py
+++ b/backend/app/tasks/transcription.py
@@ -12,6 +12,7 @@ from bson import ObjectId
 from motor.motor_asyncio import AsyncIOMotorClient
 from app.core.celery_app import celery_app
 from app.core.config import settings
+from typing import Optional
 
 logger = logging.getLogger(__name__)
 
@@ -94,23 +95,22 @@ def _download_video_sync(url: str, transcription_id: str):
             if os.path.exists(path_temp):
                 os.remove(path_temp)
             raise Exception(f'Unsupported content type: {content_type}')
-    # Case 3: Audio file attachment
     
 def _upload_to_minio_sync(filepath: str, object_name: str):
     try:
         client = Minio(
-            "minio:9000",
+            settings.MINIO_ENDPOINT,
             access_key=settings.MINIO_ROOT_USER,
             secret_key=settings.MINIO_ROOT_PASSWORD,
             secure=False
         )
-        bucket_name = "vidwhisper-engine"
-        client.fput_object(bucket_name, object_name, filepath)
+        bucket_name = settings.MINIO_BUCKET
+        client.fput_object(bucket_name, object_name, filepath, content_type='audio/mpeg')
     except S3Error as e:
         logger.error(f'Error uploading video to MinIO: {e}')
         raise e
     
-async def download_video(url: str, filepath: str, name_id: str):
+async def download_video(url: str, name_id: str):
     audio_path = f"/app/tmp/{name_id}.mp3"
 
     try:
@@ -120,9 +120,6 @@ async def download_video(url: str, filepath: str, name_id: str):
         await loop.run_in_executor(None, _upload_to_minio_sync, audio_path, f"audios/{name_id}.mp3")
         logger.info(f'Audio uploaded to MinIO as audios/{name_id}.mp3')
         
-        # Clean up local video file
-        if os.path.exists(filepath):
-            os.remove(filepath)
     except Exception as e:
         logger.error(f'Error to processing video from {url}: {e}')
         raise e
@@ -134,6 +131,20 @@ async def upload_to_minio(filepath: str, object_name: str):
         await loop.run_in_executor(None, _upload_to_minio_sync, filepath, object_name)
     except S3Error as e:
         logger.error(f'Error uploading to MinIO: {e}')
+        raise e
+
+async def delete_to_minio(object_name: str):
+    try:
+        client = Minio(
+            settings.MINIO_ENDPOINT,
+            access_key=settings.MINIO_ROOT_USER,
+            secret_key=settings.MINIO_ROOT_PASSWORD,
+            secure=False
+        )
+        bucket_name = settings.MINIO_BUCKET
+        client.remove_object(bucket_name, f'temp_uploads/{object_name.split("/")[-1]}')
+    except S3Error as e:
+        logger.error(f'Error deleting object from MinIO: {e}')
         raise e
 
 @celery_app.task(name="process_video_task")
@@ -159,12 +170,22 @@ def process_video_task(transcription_id: str, video_url: str):
             {"$set": update_doc}
         )
 
+    async def update_video_url(url: str):
+        db = await get_db()
+        # Verify if URL is 'pending' before updating
+        transcription = await db.transcriptions.find_one({"_id": ObjectId(transcription_id)})
+        if transcription and transcription.get("video_url") == "pending":
+            await db.transcriptions.update_one(
+                {"_id": ObjectId(transcription_id)},
+                {"$set": {"video_url": url}}
+            )
+
     try:
         # Change status to 'pending'
         loop.run_until_complete(update_status('processing'))
 
         # Download video and convert to audio
-        loop.run_until_complete(download_video(video_url, video_path, transcription_id))
+        loop.run_until_complete(download_video(video_url, transcription_id))
         
         # Transcribe audio
         logger.info(f'Starting transcription for ID: {transcription_id}')
@@ -177,6 +198,7 @@ def process_video_task(transcription_id: str, video_url: str):
         # gc.collect()
 
         # Update status to 'completed'
+        loop.run_until_complete(update_video_url(f'http://{settings.MINIO_ENDPOINT}/{settings.MINIO_BUCKET}/audios/{transcription_id}.mp3'))
         loop.run_until_complete(update_status('completed', {"text": transcribed_text}))
 
         return { "status": "success", "id": transcription_id }
@@ -190,3 +212,7 @@ def process_video_task(transcription_id: str, video_url: str):
             if os.path.exists(path):
                 os.remove(path)
                 # logger.info(f'Cleaned up temporary files for ID: {transcription_id}')
+
+        # Delete audio/video temp files from MinIO
+        if video_url and settings.MINIO_ENDPOINT in video_url:
+            loop.run_until_complete(delete_to_minio(video_url))

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -16,3 +16,4 @@ redis==5.0.8
 openai-whisper==20250625
 ffmpeg-python==0.2.0
 requests==2.32.5
+yt-dlp==2025.12.8

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -13,3 +13,6 @@ pytest==9.0.2
 pytest-asyncio==1.3.0
 celery==5.4.0
 redis==5.0.8
+openai-whisper==20250625
+ffmpeg-python==0.2.0
+requests==2.32.5

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -60,7 +60,13 @@ services:
       context: ./backend
       dockerfile: Dockerfile
     container_name: vidwhisper-worker
-    command: celery -A app.core.celery_app worker --loglevel=info
+    command: celery -A app.core.celery_app worker --loglevel=info --concurrency=1 --pool=threads
+    deploy:
+      resources:
+        limits:
+          memory: 4G
+        reservations:
+          memory: 2G
     env_file:
       - ./backend/.env
     depends_on:


### PR DESCRIPTION
This PR concludes Issue #4, introducing the ability to process transcripts from three different sources and establishing a history management system. A decoupled architecture has been implemented using MinIO as a buffer for physical files, avoiding isolation conflicts between containers.

**Changes Made**

1. Transcription Endpoints
**POST /:** Processes direct YouTube links and external URLs (audio/video).
**POST /file:** New endpoint that allows uploading physical files (.mp3 and .mp4). The file is temporarily stored in a MinIO bucket (temp_uploads) so the Worker can access it.

2. Worker Logic (Celery + Whisper)
**File Synchronization:** The worker downloads the file from MinIO (if it's a physical upload) or from the provided URL.
**Video Processing:** ffmpeg is used to extract audio from video files before sending them to Whisper.
**Persistence:** The final audio is saved in a permanent bucket (audios/) and the database is updated with the final URL and the transcribed text.

3. Data Management (CRUD)
**GET /:** Implementation of a transcription history for the dashboard.
**DELETE /{id}:** Logical and physical deletion, removing the record in MongoDB and the associated .mp3 file in MinIO.

**Related Issue:** Closes #4